### PR TITLE
Switch click handlers to `addEventListener`, validate cancel-queue storage, and update linter config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,5 +2,9 @@
     "env": {
         "builtin": true
     },
+    "categories": {
+        "correctness": "error",
+        "suspicious": "error"
+    },
     "ignorePatterns": ["dist/**"]
 }

--- a/src/deliveries.ts
+++ b/src/deliveries.ts
@@ -77,7 +77,7 @@ function processDeliveryCard(deliveryCard: HTMLElement) {
         marginTop: '10px',
     });
 
-    cancelAllButton.onclick = async () => {
+    cancelAllButton.addEventListener('click', async () => {
         if (
             !confirm(
                 `Are you sure you want to cancel ${deliveryCardSubscriptionIds.length} subscriptions in this delivery?\n\nThe screen will automatically refresh after each cancellation and cancel the next subscription.  Do not click on anything until it is all done.`,
@@ -88,7 +88,7 @@ function processDeliveryCard(deliveryCard: HTMLElement) {
 
         await addToCancelQueue(deliveryCardSubscriptionIds);
         await processCancelQueue(itemCancelButtonButtonBySubscriptionId);
-    };
+    });
 
     deliveryInformationContainer.appendChild(cancelAllButton);
 }

--- a/src/sessionStorage.ts
+++ b/src/sessionStorage.ts
@@ -30,13 +30,15 @@ export async function removeCancelSubmitted() {
 export async function getCancelQueue(): Promise<string[]> {
     const value = await chromeStorageLocalGetWithRetry(ONECLICK_CANCEL_QUEUE_KEY);
 
-    const storageValue = value[ONECLICK_CANCEL_QUEUE_KEY] as unknown;
+    const storageValue = value[ONECLICK_CANCEL_QUEUE_KEY];
 
     if (!storageValue) return [];
 
     if (!Array.isArray(storageValue)) return [];
 
-    return storageValue as string[];
+    if (!storageValue.every((entry) => typeof entry === 'string')) return [];
+
+    return [...storageValue];
 }
 
 export async function addToCancelQueue(subscriptionIds: string[]) {

--- a/src/subscriptionCard.ts
+++ b/src/subscriptionCard.ts
@@ -40,7 +40,7 @@ export function processSubscriptionCard(subscriptionCard: HTMLElement): {
         marginTop: '10px',
     });
 
-    cancelButton.onclick = () => {
+    cancelButton.addEventListener('click', () => {
         // click on the subscription image to open edit subscription modal
         const editSubscriptionModalTrigger = subscriptionCard.querySelector<HTMLElement>(
             '.subscription-image-container > span',
@@ -55,7 +55,7 @@ export function processSubscriptionCard(subscriptionCard: HTMLElement): {
         observeEditSubscriptionModal();
 
         editSubscriptionModalTrigger.click();
-    };
+    });
 
     subscriptionCard.appendChild(cancelButton);
 

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -82,7 +82,7 @@ function addCancelAllButton() {
         marginLeft: '30px',
     });
 
-    cancelAllButton.onclick = async () => {
+    cancelAllButton.addEventListener('click', async () => {
         if (
             !confirm(
                 `Are you sure you want to cancel ${subscriptionsCount} subscriptions?\n\nThe screen will automatically refresh after each cancellation and cancel the next subscription. Do not click on anything until it is all done.`,
@@ -95,7 +95,7 @@ function addCancelAllButton() {
 
         await addToCancelQueue(subscriptionIds);
         await processCancelQueue(itemCancelButtonButtonBySubscriptionId);
-    };
+    });
 
     subscriptionFilters.insertAdjacentElement('beforeend', cancelAllButton);
 }


### PR DESCRIPTION
### Motivation
- Replace direct `onclick` assignments with `addEventListener('click', ...)` to avoid clobbering other click handlers and follow best practices for event handling.
- Harden retrieval of the cancel queue from Chrome storage to ensure stored values are arrays of strings and to avoid returning mutable or malformed data.
- Update linter configuration to explicitly enable `correctness` and `suspicious` categories.

### Description
- Replaced `element.onclick = ...` with `element.addEventListener('click', ...)` in `src/deliveries.ts`, `src/subscriptionCard.ts`, and `src/subscriptions.ts` to attach click handlers non-destructively.
- Tightened `getCancelQueue()` in `src/sessionStorage.ts` to avoid unsafe casts, validate that storage entries are strings, and return a shallow copy of the queue array.
- Added `categories.correctness` and `categories.suspicious` to `.oxlintrc.json` and left `ignorePatterns` intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d3b97fec8327a9d245d34d552838)